### PR TITLE
cleanup f4go. add logging facilities. better intrinsics

### DIFF
--- a/fortran/logger.go
+++ b/fortran/logger.go
@@ -1,0 +1,44 @@
+package fortran
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+var (
+	Verbose int
+	writer  io.Writer = os.Stdout
+)
+
+func Debugf(format string, a ...interface{}) {
+	if Verbose >= 3 {
+		logf(format, a...)
+	}
+}
+
+func Infof(format string, a ...interface{}) {
+	if Verbose >= 2 {
+		logf(format, a...)
+	}
+}
+
+func Logf(format string, a ...interface{}) {
+	if Verbose >= 1 {
+		logf(format, a...)
+	}
+}
+
+func Errorf(format string, a ...interface{}) {
+	logf(format, a...)
+}
+
+// Ensures log prints with newline at end
+func logf(format string, a ...interface{}) {
+	if strings.HasSuffix(format, "\n") {
+		fmt.Fprintf(writer, format, a...)
+	} else {
+		fmt.Fprintf(writer, format+"\n", a...)
+	}
+}

--- a/fortran/scan.go
+++ b/fortran/scan.go
@@ -77,9 +77,8 @@ type scanner struct {
 var Debug bool = true // false
 
 func scan(b []byte) (ns []node) {
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Begin of scan\n")
-	}
+	Debugf("Begin of scan")
+
 	var s scanner
 	s.nodes = list.New()
 	s.nodes.PushFront(&node{
@@ -97,86 +96,58 @@ func scan(b []byte) (ns []node) {
 	}()
 
 	// separate lines
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: break lines\n")
-	}
+	Debugf("Scan: break lines")
 	s.scanBreakLines()
 
 	// separate comments
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: comments\n")
-	}
+	Debugf("Scan: comments")
 	s.scanComments()
 
 	// merge lines
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: merge lines\n")
-	}
+	Debugf("Scan: merge lines")
 	s.mergeLines()
 
 	// separate strings
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: strings\n")
-	}
+	Debugf("Scan: strings")
 	s.scanStrings()
 
 	// comments !
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: comments !\n")
-	}
+	Debugf("Scan: comments !")
 	s.scanNextComments()
 
 	// preprocessor: add specific spaces
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: tokens with point\n")
-	}
+	Debugf("Scan: tokens with point")
 	s.scanTokenWithPoint()
 
 	// move comments
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: move comments after RPAREN\n")
-	}
+	Debugf("Scan: move comments after RPAREN")
 	s.scanMoveComment()
 
 	// separate on other token
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: tokens\n")
-	}
+	Debugf("Scan: tokens")
 	s.scanTokens()
 
 	// remove empty
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: empty\n")
-	}
+	Debugf("Scan: empty")
 	s.scanEmpty()
 
 	// scan numbers
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: numbers\n")
-	}
+	Debugf("Scan: numbers")
 	s.scanNumbers()
 
 	// remove empty
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: empty\n")
-	}
+	Debugf("Scan: empty")
 	s.scanEmpty()
 
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: after tokens\n")
-	}
+	Debugf("Scan: after tokens")
 	s.scanTokensAfter()
 
 	// remove empty
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: empty\n")
-	}
+	Debugf("Scan: empty")
 	s.scanEmpty()
 
 	// IDENT for undefine
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: undefine idents\n")
-	}
+	Debugf("Scan: undefine idents")
 	for e := s.nodes.Front(); e != nil; e = e.Next() {
 		switch e.Value.(*node).tok {
 		case ftUndefine:
@@ -186,20 +157,14 @@ func scan(b []byte) (ns []node) {
 	}
 
 	// token GO TO
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: token GOTO\n")
-	}
+	Debugf("Scan: token GOTO")
 	s.scanGoto()
 
 	// postprocessor
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: run postprocessor\n")
-	}
+	Debugf("Scan: run postprocessor")
 	s.postprocessor()
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Scan: end of postprocessor\n")
-	}
 
+	Debugf("Scan: end of postprocessor")
 	return
 }
 
@@ -715,9 +680,9 @@ impl:
 	iter++
 	if iter > 100000 {
 		panic(fmt.Errorf("Too many IMPLICIT iterations"))
-	} else if Debug {
-		fmt.Fprintf(os.Stdout, "finding next IMPLICIT...  %d\n", iter)
 	}
+	Debugf("finding next IMPLICIT...  %d", iter)
+
 	for e := s.nodes.Front(); e != nil; e = e.Next() {
 		if e.Value.(*node).tok != ftImplicit {
 			continue
@@ -954,14 +919,11 @@ func (s *scanner) scanMoveComment() {
 		}
 	}
 	if left != rigth {
-		if Debug {
-			fmt.Fprintf(os.Stdout, "Amount of left and rigth paren is not same: %d != %d\n", left, rigth)
-		}
+		Debugf("Amount of left and rigth paren is not same: %d != %d", left, rigth)
+
 		return
 	}
-	if Debug {
-		fmt.Fprintf(os.Stdout, "Amount of left and rigth paren is same: %d\n", left)
-	}
+	Debugf("Amount of left and rigth paren is same: %d", left)
 }
 
 func (s *scanner) scanTokens() {
@@ -1229,9 +1191,7 @@ numb:
 		}
 	}
 	if again {
-		if Debug {
-			fmt.Fprintf(os.Stdout, "rescan numbers\n")
-		}
+		Debugf("rescan numbers")
 		goto numb
 	}
 }

--- a/intrinsic/math.go
+++ b/intrinsic/math.go
@@ -6,6 +6,10 @@ import (
 	"math/cmplx"
 )
 
+const (
+	eps = 1.1920928955078125e-07 // math.Pow(2,-23) = 1.1920928955078125e-07 (EPSILON)
+)
+
 func MIN(a, b int) int {
 	if a < b {
 		return a
@@ -46,20 +50,15 @@ func SQRT(a interface{}) float64 {
 }
 
 func MAX(a, b interface{}) float64 {
-	A := castToFloat64(a)
-	B := castToFloat64(b)
-	if A > B {
-		return A
-	}
-	return B
+	return math.Max(castToFloat64(a), castToFloat64(b))
 }
 
 func EPSILON(f float64) float64 {
-	return math.Pow(2, -23)
+	return eps
 }
 
 func CONJG(c complex128) complex128 {
-	return complex128(cmplx.Conj(complex128(c)))
+	return cmplx.Conj(complex128(c))
 }
 
 func DCONJG(c complex128) complex128 {
@@ -67,21 +66,21 @@ func DCONJG(c complex128) complex128 {
 }
 
 func DBLE(a interface{}) float64 {
-	switch a.(type) {
+	switch a := a.(type) {
 	case int:
-		return float64(a.(int))
+		return float64(a)
 	case int32:
-		return float64(a.(int32))
+		return float64(a)
 	case int64:
-		return float64(a.(int64))
+		return float64(a)
 	case float32:
-		return float64(a.(float32))
+		return float64(a)
 	case complex64:
-		return float64(real(a.(complex64)))
+		return float64(real(a))
 	case complex128:
-		return float64(real(a.(complex128)))
+		return float64(real(a))
 	case float64:
-		return a.(float64)
+		return a
 	}
 	panic(fmt.Errorf("Cannot find type : %T", a))
 }
@@ -95,10 +94,7 @@ func CABS(a complex128) float64 {
 }
 
 func SIGN(a float64) float64 {
-	if a < 0.0 {
-		return -1
-	}
-	return 1
+	return math.Copysign(1, a)
 }
 
 func MOD(a, b int) int {


### PR DESCRIPTION
Hey, thought you could use some improvements to logging since running f4go in parallel usually spits out too much data to meaningfully process and no trace of which file was being processed when panic happened. Please take a look!